### PR TITLE
Input polarity, error checking

### DIFF
--- a/MCP23017.cpp
+++ b/MCP23017.cpp
@@ -201,16 +201,16 @@ bool MCP23017::pinMode8(uint8_t port, uint8_t value, uint8_t input_polarity, uin
     return false;
   }
   if (port == 0) {
-  	if (! writeReg(MCP23017_DDR_A, value)) return false;
-	  if (! writeReg(MCP23017_POL_A, input_polarity)) return false;
-	  if (! writeReg(MCP23017_PUR_A, input_pullup)) return false;
+    if (! writeReg(MCP23017_DDR_A, value)) return false;
+    if (! writeReg(MCP23017_POL_A, input_polarity)) return false;
+    if (! writeReg(MCP23017_PUR_A, input_pullup)) return false;
   }
   if (port == 1) {
     if (! writeReg(MCP23017_DDR_B, value) return false;
-	  if (! writeReg(MCP23017_POL_B, input_polarity) return false;
-	  if (! writeReg(MCP23017_PUR_B, input_pullup) return false;
+    if (! writeReg(MCP23017_POL_B, input_polarity) return false;
+    if (! writeReg(MCP23017_PUR_B, input_pullup) return false;
   }
-  return (_error == MCP23017_OK);
+  return true;
 }
 
 

--- a/MCP23017.cpp
+++ b/MCP23017.cpp
@@ -206,9 +206,9 @@ bool MCP23017::pinMode8(uint8_t port, uint8_t value, uint8_t input_polarity, uin
     if (! writeReg(MCP23017_PUR_A, input_pullup)) return false;
   }
   if (port == 1) {
-    if (! writeReg(MCP23017_DDR_B, value) return false;
-    if (! writeReg(MCP23017_POL_B, input_polarity) return false;
-    if (! writeReg(MCP23017_PUR_B, input_pullup) return false;
+    if (! writeReg(MCP23017_DDR_B, value)) return false;
+    if (! writeReg(MCP23017_POL_B, input_polarity)) return false;
+    if (! writeReg(MCP23017_PUR_B, input_pullup)) return false;
   }
   return true;
 }

--- a/MCP23017.h
+++ b/MCP23017.h
@@ -2,7 +2,7 @@
 //
 //    FILE: MCP23017.h
 //  AUTHOR: Rob Tillaart
-// VERSION: 0.2.3
+// VERSION: 0.2.4
 // PURPOSE: Arduino library for I2C MCP23017 16 channel port expander
 //    DATE: 2019-10-12
 //     URL: https://github.com/RobTillaart/MCP23017_RT
@@ -12,7 +12,7 @@
 #include "Wire.h"
 
 
-#define MCP23017_LIB_VERSION    (F("0.2.3"))
+#define MCP23017_LIB_VERSION    (F("0.2.4"))
 
 #define MCP23017_OK              0x00
 #define MCP23017_PIN_ERROR       0x81
@@ -39,7 +39,7 @@ public:
 
   // single pin interface
   // mode = INPUT, OUTPUT or INPUT_PULLUP (==INPUT)
-  bool    pinMode(uint8_t pin, uint8_t mode);
+  bool    pinMode(uint8_t pin, uint8_t mode, bool reversed=false);
   bool    digitalWrite(uint8_t pin, uint8_t value);
   uint8_t digitalRead(uint8_t pin);
 
@@ -47,7 +47,7 @@ public:
   // 8 pins interface
   // port  = 0..1
   // value = bitpattern
-  bool    pinMode8(uint8_t port, uint8_t value);
+  bool    pinMode8(uint8_t port, uint8_t value, uint8_t input_polarity=0x00, uint8_t input_pullup=0xFF);
   bool    write8(uint8_t port, uint8_t value);
   int     read8(uint8_t port);
 


### PR DESCRIPTION
Hi Rob, as I mentioned at AM2320 case, I tried to improve your MCP driver. 

I have added a possibility to define input polarity for pinMode and pinMode8.
There are default values of new arguments so all previous code can use the improved methods.
(These improvements are usefull but not necessary in case you do not like them).

When detecting failures of AM2320 I also wanted to detect failures of MCP23017, but I have found that in some cases
the failure in private method of this driver is masked by calling methods inside the driver and true can be returned  to outside
even the failure inside happened.  So I changed the code to detect any failure even when there are three consecutive calls, two are ok and third fails. I know it is unprobable, but I wanted be sure that I detect every failure.
(By MCP any failure that results in incorrect chip configuration or in incorrect output state can result in a damage, therefore I want to be sure that the returned error code is always gives correct information). 