### PR TITLE
Add '8' interface for enable/disable interrupts

### DIFF
--- a/MCP23017.cpp
+++ b/MCP23017.cpp
@@ -726,6 +726,17 @@ uint16_t MCP23017::getInterruptCaptureRegister()
 }
 
 
+uint8_t MCP23017::getInterruptCaptureRegister8(uint8_t port)
+{
+  if (port > 1)
+  {
+    _error = MCP23017_PORT_ERROR;
+    return false;
+  }
+  return readReg(port == 0 ? MCP23x17_INTCAP_A : MCP23x17_INTCAP_B);
+}
+
+
 //       polarity: 0 = LOW, 1 = HIGH, 2 = NONE/ODR
 bool MCP23017::setInterruptPolarity(uint8_t polarity)
 {

--- a/MCP23017.cpp
+++ b/MCP23017.cpp
@@ -628,6 +628,42 @@ bool MCP23017::disableInterrupt(uint8_t pin)
 }
 
 
+bool MCP23017::enableInterrupt8(uint8_t port, uint8_t mask, uint8_t mode)
+{
+  if (port > 1)
+  {
+    _error = MCP23017_PORT_ERROR;
+    return false;
+  }
+
+  uint16_t intcon = 0, defval = 0;
+  //  right mode
+  if (mode == CHANGE)
+  {
+    //  compare to previous value.
+    intcon = ~mask;
+  }
+  else
+  {
+    if (mode == RISING)
+    {
+      intcon = mask;
+      defval = ~mask;  //  RISING == compare to 0
+    }
+    else if (mode == FALLING)
+    {
+      intcon = mask;
+      defval = mask;  //  FALLING == compare to 1
+    }
+    writeReg(port == 0 ? MCP23x17_DEFVAL_A: MCP23x17_DEFVAL_B, defval);
+  }
+  writeReg(port == 0 ? MCP23x17_INTCON_A : MCP23x17_INTCON_B, intcon);
+
+  //  enable the mask
+  writeReg(port == 0 ? MCP23x17_GPINTEN_A : MCP23x17_GPINTEN_B, mask);
+  return true;
+}
+
 bool MCP23017::enableInterrupt16(uint16_t mask, uint8_t mode)
 {
   uint16_t intcon = 0, defval = 0;
@@ -656,6 +692,18 @@ bool MCP23017::enableInterrupt16(uint16_t mask, uint8_t mode)
   //  enable the mask
   writeReg16(MCP23x17_GPINTEN_A, mask);
   return true;
+}
+
+
+bool MCP23017::disableInterrupt8(uint8_t port, uint8_t mask)
+{
+  if (port > 1)
+  {
+    _error = MCP23017_PORT_ERROR;
+    return false;
+  }
+
+  return writeReg(port == 0 ? MCP23x17_GPINTEN_A : MCP23x17_GPINTEN_B, ~mask);
 }
 
 

--- a/MCP23017.h
+++ b/MCP23017.h
@@ -85,6 +85,10 @@ public:
   bool     enableInterrupt(uint8_t pin, uint8_t mode);
   bool     disableInterrupt(uint8_t pin);
 
+  //       mask = 0x00..0xFF  (overrides all earlier settings.
+  bool     enableInterrupt8(uint8_t port, uint8_t mask, uint8_t mode);
+  bool     disableInterrupt8(uint8_t port, uint8_t mask);
+
   //       mask = 0x0000..0xFFFF  (overrides all earlier settings.
   bool     enableInterrupt16(uint16_t mask, uint8_t mode);
   bool     disableInterrupt16(uint16_t mask);

--- a/MCP23017.h
+++ b/MCP23017.h
@@ -96,6 +96,7 @@ public:
   //       which pins caused the INT?
   uint16_t getInterruptFlagRegister();
   uint16_t getInterruptCaptureRegister();
+  uint8_t getInterruptCaptureRegister8(uint8_t port);
 
   //       polarity: 0 = LOW, 1 = HIGH, 2 = NONE/ODR
   bool     setInterruptPolarity(uint8_t polarity);


### PR DESCRIPTION
Hi again Rob!

Turns out I've been using quite a few of your libraries, they are much appreciated!

I'm using one "bank" of an MCP23017 to read a 4x4 keypad, leaving the other half for miscellaneous stuff. So to be efficient and not affect the other half I needed the `enableInterrupt8` interface, and also added disable for consistency.

They are pure copy/paste of the existing ones, with the added port-check in the beginning and address select at the end.

Let me know if you have any feedback, Thanks again!

edit: Realised that I needed to be able to read (i.e. clear) the interrupt too..